### PR TITLE
Support fractional zoom levels in Leaflet

### DIFF
--- a/src/L.Maidenhead.js
+++ b/src/L.Maidenhead.js
@@ -39,8 +39,8 @@ L.Maidenhead = L.LayerGroup.extend({
 		var lat_cor =    new Array(0 ,8 ,8 ,8 ,10,14,6 ,8 ,8 ,8 ,1.4 ,2.5 ,3   ,3.5 ,4   ,4    ,3.5  ,3.5  ,1.47    ,1.8     ,1.6      );
 		var bounds = map.getBounds();
 		var zoom = map.getZoom();
-		var unit = d3[zoom];
-		var lcor = lat_cor[zoom];
+		var unit = d3[Math.round(zoom)];
+		var lcor = lat_cor[Math.round(zoom)];
 		var w = bounds.getWest();
 		var e = bounds.getEast();
 		var n = bounds.getNorth();
@@ -68,7 +68,7 @@ L.Maidenhead = L.LayerGroup.extend({
 	_getLabel: function(lon,lat) {
 	  var title_size = new Array(0 ,10,12,16,20,26,12,16,24,36,12  ,14  ,20  ,36  ,60  ,12   ,20   ,36   ,8   ,12      ,24       );
 	  var zoom = map.getZoom();
-	  var size = title_size[zoom]+'px';
+	  var size = title_size[Math.round(zoom)]+'px';
 	  var title = '<span style="cursor: default;"><font style="color:'+this.options.color+'; font-size:'+size+'; font-weight: 900; ">' + this._getLocator(lon,lat) + '</font></span>';
       var myIcon = L.divIcon({className: 'my-div-icon', html: title});
       var marker = L.marker([lat,lon], {icon: myIcon}, clickable=false);
@@ -83,7 +83,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var locator = "";
       var x = lon;
       var y = lat;
-      var precision = d4[map.getZoom()];
+      var precision = d4[Math.round(map.getZoom())];
       while (x < -180) {x += 360;}
       while (x > 180) {x -=360;}
       x = x + 180;


### PR DESCRIPTION
First of all, thank you very much for making this layer!

I have been using it in a web app which now offers finer control of zoom levels by using Leaflet's fractional zoom capability. I have noticed that the Maidenhead grid layer only renders when the zoom level is an integer, and not at all when a fractional zoom is used.

This is due to the code using the zoom level as an index into the arrays that control detail level and precision.

This PR simply adds `Math.round()` where zoom levels are used as array indices, and fixes this issue.

To test, enable fractional zoom in Leaflet, for example in the example `index.html`, modify the line where the map is created to this:

```js
    var map = L.map('map', {
        zoomDelta: 0.25,
        zoomSnap: 0,
        wheelPxPerZoomLevel: 200
    }).setView([46, 19], 5);
```

This will then zoom fractionally when the scroll wheel is used. You will see that with the existing code, the Maidenhead grid does not appear at some zoom levels.

When using the modified code from this PR, the grid should appear at all zoom levels, including the fractional ones.

73 de Ian M0TRT